### PR TITLE
Redo of PR #200

### DIFF
--- a/client/src/components/screens/VariantDetails/index.jsx
+++ b/client/src/components/screens/VariantDetails/index.jsx
@@ -715,8 +715,7 @@ class VariantDetailsScreen extends React.Component {
         dataId, panel,
       } = on;
 
-      const re = /(?<=Orph:)\d+(\.\d*)?/;
-
+      const re = RegExp(/([Orph:])\d+(\.\d*)?/, 'i');
       const orphaId = panel ? re.exec(panel)[0] : '';
 
       return (
@@ -766,7 +765,7 @@ class VariantDetailsScreen extends React.Component {
     if (genes.filter(g => !!g.hpo).length > 0) {
       return genes.map((g, index) => {
         const lis = g.hpo ? g.hpo.map((h) => {
-          const re = /(?<=HP:)\d+(\.\d*)?/;
+          const re = RegExp(/([HP:])\d+(\.\d*)?/, 'i');
           const hpoId = re.exec(h)[0];
           const url = `https://hpo.jax.org/app/browse/term/HP:${hpoId}`;
           return (<a href={url}>{h}</a>);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clin-frontend",
-  "version": "2.4.0",
+  "version": "2.4.2",
   "versionName": "Alpha Strain",
   "dependencies": {
     "@babel/core": "7.2.2",


### PR DESCRIPTION
Same fix as in PR #200. Using a regex format that Firefox understands. Used in the Variant Details page, for Orphanet and Hpo tables.