### PR TITLE
fix: #505 search bar hover

### DIFF
--- a/client/src/style/themes/antd-clin-theme.css
+++ b/client/src/style/themes/antd-clin-theme.css
@@ -1495,7 +1495,7 @@ html {
   font-feature-settings: 'tnum';
 }
 .ant-select-auto-complete.ant-select .ant-select-selection {
-  border: 0;
+  border-color: transparent;
   box-shadow: none;
 }
 .ant-select-auto-complete.ant-select .ant-select-selection__rendered {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clin-frontend",
-  "version": "3.0.65",
+  "version": "3.0.66",
   "versionName": "Alpha Strain",
   "dependencies": {
     "@babel/core": "7.2.2",


### PR DESCRIPTION
- Change autocomplete border in theme
  - The theme removed the border but the hover adds one creating the layout shift so I'm setting the border as transparent instead

