### PR TITLE
feat: #449 Confirmation modal on cancel button

### DIFF
--- a/client/src/components/ConfirmationModal/index.jsx
+++ b/client/src/components/ConfirmationModal/index.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import intl from 'react-intl-universal';
+import { Modal } from 'antd';
+import IconKit from 'react-icons-kit';
+import { ic_info_outline } from 'react-icons-kit/md/ic_info_outline';
+
+function ConfirmationModal({ onOk, onCancel }) {
+  Modal.confirm({
+    icon: <span className="anticon"><IconKit size={24} icon={ic_info_outline} /></span>,
+    title: intl.get('components.confirmationModal.title'),
+    okText: intl.get('components.confirmationModal.okText'),
+    cancelText: intl.get('components.confirmationModal.cancelText'),
+    onOk,
+    onCancel,
+  });
+}
+
+export default ConfirmationModal;

--- a/client/src/components/screens/PatientSubmission/index.jsx
+++ b/client/src/components/screens/PatientSubmission/index.jsx
@@ -43,6 +43,7 @@ import { FhirDataManager } from '../../../helpers/fhir/fhir_data_manager.ts';
 import { ObservationBuilder } from '../../../helpers/fhir/builder/ObservationBuilder.ts';
 import { FamilyMemberHistoryBuilder } from '../../../helpers/fhir/builder/FMHBuilder.ts';
 import Layout from '../../Layout';
+import ConfirmationModal from '../../ConfirmationModal';
 
 const { Step } = Steps;
 
@@ -993,7 +994,7 @@ class PatientSubmissionScreen extends React.Component {
                   { intl.get('screen.clinicalSubmission.saveButtonTitle') }
                 </Button>
                 <Button
-                  onClick={actions.navigateToPatientSearchScreen}
+                  onClick={() => ConfirmationModal({ onOk: () => { actions.navigateToPatientSearchScreen(); } })}
                   className="cancelButton"
                 >
                   { intl.get('screen.clinicalSubmission.cancelButtonTitle') }

--- a/client/src/locales/en.js
+++ b/client/src/locales/en.js
@@ -549,6 +549,9 @@ const en = {
   'components.table.action.createReport': 'Create Report',
   'components.table.action.columns': 'Columns',
   'components.table.action.organize': 'Organize',
+  'components.confirmationModal.title': 'Quit without saving your changes?',
+  'components.confirmationModal.okText': 'Quit',
+  'components.confirmationModal.cancelText': 'Cancel',
 };
 
 export default en;

--- a/client/src/locales/fr.js
+++ b/client/src/locales/fr.js
@@ -549,6 +549,9 @@ const fr = {
   'components.table.action.createReport': 'Créer Rapport',
   'components.table.action.columns': 'Columns',
   'components.table.action.organize': 'Organizer',
+  'components.confirmationModal.title': 'Quitter sans sauvegarder les modifications?',
+  'components.confirmationModal.okText': 'Quitter',
+  'components.confirmationModal.cancelText': 'Annuler',
 };
 
 export default fr;


### PR DESCRIPTION
- Creates a reusable confirmation modal
- Use it on the prescription form

![image](https://user-images.githubusercontent.com/6840361/99588444-91b1c500-29b8-11eb-91d2-2c51d28b05f2.png)
