### PR TITLE
fix: remove Francis Provost as owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @claudia1296 @francisprovost @YanLabCHU @francisl
+*   @claudia1296 @YanLabCHU @francisl


### PR DESCRIPTION
Retirer  Francis Provost des 'Owner' puisqu'il a quitté