### PR TITLE
fix(navigation header): #clin211 make sure navigation is correctly di…

### DIFF
--- a/client/src/reducers/user.js
+++ b/client/src/reducers/user.js
@@ -42,9 +42,9 @@ const userReducer = (state = ({ ...initialUserState }), action) => produce(state
       break;
 
     case actions.USER_IDENTITY_SUCCEEDED:
-      draft.username = action.payload.username;
-      draft.firstName = action.payload.firstName;
-      draft.lastName = action.payload.lastName;
+      draft.username = action.payload.preferred_username;
+      draft.firstName = action.payload.given_name;
+      draft.lastName = action.payload.family_name;
       draft.practitionerId = get(action.payload, 'attributes.fhir_practitioner_id[0]', '');
       break;
 

--- a/client/src/sagas/user.js
+++ b/client/src/sagas/user.js
@@ -21,7 +21,7 @@ function* logout() {
 
 function* identity() {
   try {
-    const response = yield keycloak.loadUserProfile();
+    const response = yield keycloak.loadUserInfo();
     yield put({ type: actions.USER_IDENTITY_SUCCEEDED, payload: response });
   } catch (e) {
     yield put({ type: actions.USER_IDENTITY_FAILED, payload: e });


### PR DESCRIPTION
# BUG: _Connexion avec compte de test n'affiche pas le nom et le prenom_

closes https://ferlab-crsj.atlassian.net/browse/CLIN-211

## Description

One can see the navigation bar (disconnect button) for any user.

## Validation

- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot (Avant et Après)
![clinFixLogoutGeneticianLogout](https://user-images.githubusercontent.com/54366437/132933080-0bf1d49e-a86c-4486-86dd-20c47fa5d0e6.png)


## QA

login with a user such as genetician or bioinformatician and check that you can correctly logout via navigation bar. Moreover, make sure that the user info are correctly displayed through out the whole application (I fetched info from a new endpoint so)
...

## Note
keycloack.loadUserProfile() let to cors issue on some user. I used keycloack.loadUserInfo endpoint instead.
