### PR TITLE
fix #235 only enable add parent btn when a proband with no parents

### DIFF
--- a/client/src/components/screens/Patient/components/FamilyTab/index.tsx
+++ b/client/src/components/screens/Patient/components/FamilyTab/index.tsx
@@ -30,7 +30,8 @@ const FamilyTab = (): React.ReactElement => {
   const [addParentType, setAddParentType] = useState<FamilyMemberType | null>(null);
 
   const patientId = patient.id;
-  const isPatientProband = patient.proband;
+
+  const isPatientProband = patient.proband?.toLowerCase() === 'proband';
 
   const hasMother = hasAtLeastOneMotherInMembers(familyMembers);
   const canAddMother = isPatientProband && !hasMother;
@@ -38,33 +39,21 @@ const FamilyTab = (): React.ReactElement => {
   const hasFather = hasAtLeastOneFatherInMembers(familyMembers);
   const canAddFather = isPatientProband && !hasFather;
 
-  const canAddAtLeastOneParent = !hasFather || !hasMother;
+  const canAddAtLeastOneParent = canAddMother || canAddFather;
 
   const menu = (
-    <Menu>
+    <Menu
+      disabled={!canAddAtLeastOneParent}
+      onClick={(e) => {
+        setAddParentType(e.key as FamilyMemberType);
+        setIsVisible(false);
+      }}
+    >
       <Menu.Item disabled={!canAddMother} key={FamilyMemberType.MOTHER}>
-        <Button
-          disabled={hasMother}
-          onClick={() => {
-            setAddParentType(FamilyMemberType.MOTHER);
-            setIsVisible(false);
-          }}
-          type="text"
-        >
-          {intl.get('screen.patient.details.family.mother')}
-        </Button>
+        {intl.get('screen.patient.details.family.mother')}
       </Menu.Item>
       <Menu.Item disabled={!canAddFather} key={FamilyMemberType.FATHER}>
-        <Button
-          disabled={hasFather}
-          onClick={() => {
-            setAddParentType(FamilyMemberType.FATHER);
-            setIsVisible(false);
-          }}
-          type="text"
-        >
-          {intl.get('screen.patient.details.family.father')}
-        </Button>
+        {intl.get('screen.patient.details.family.father')}
       </Menu.Item>
     </Menu>
   );


### PR DESCRIPTION
# [BUG ] [Enable "add parent btn" only when proband with no parents]

closes #[235]

## Description
only a proband can add a parent if does not have one already. 

## Validation

- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
![image](https://user-images.githubusercontent.com/54366437/135154471-e4108d3e-e54f-46ba-96b6-c387b34bce38.png)

Note: some old data are really messed up and can create weird results. Please make sure that data is ok before rejecting QA. Lastly, I had to remove inner buttons in menu items. It was an improper use of React.

![image](https://user-images.githubusercontent.com/54366437/135154761-0f31f4e1-5952-4181-9ef2-71b5e325c31e.png)



