### PR TITLE
fix: #298 show fetus genre when available

### DIFF
--- a/client/src/components/screens/Patient/components/FamilyTab/components/FamilyTable.tsx
+++ b/client/src/components/screens/Patient/components/FamilyTab/components/FamilyTable.tsx
@@ -26,7 +26,7 @@ interface DataType {
 }
 
 const renderExceptIfFetus = (value: string, record: DataType) =>
-  !value || (isFetusOnly(record.member) ? '--' : value);
+  !value || isFetusOnly(record.member) ? '--' : value;
 
 const sortProbandFirst = (members: FamilyMember[]) =>
   members.slice().sort((a, b) => +b.isProband - +a.isProband);
@@ -64,10 +64,8 @@ const FamilyTable = ({ addParentMenu, canAddAtLeastOneParent }: Props): React.Re
     },
     {
       dataIndex: ['member', 'gender'],
-      render: (value: string, record: DataType) =>
-        !value || isFetusOnly(record.member)
-          ? '--'
-          : intl.get(`screen.patient.details.family.table.sex.${value}`),
+      render: (value: string) =>
+        intl.get(`screen.patient.details.family.table.sex.${value}`).defaultMessage('--'),
       title: intl.get('screen.patient.details.family.table.sex'),
       width: 200,
     },

--- a/client/src/components/screens/Patient/components/PatientDetails/index.tsx
+++ b/client/src/components/screens/Patient/components/PatientDetails/index.tsx
@@ -84,11 +84,9 @@ const PatientDetails = ({ canEditPatient, patient }: Props): React.ReactElement 
         <DetailsCol align={hasMultipleMrn ? 'top' : 'center'}>
           <DetailsRow
             title={intl.get('screen.patient.details.gender')}
-            value={intl.get(
-              `screen.patient.details.${
-                patient.isFetus ? 'unknown' : patient.gender.toLowerCase()
-              }`,
-            )}
+            value={intl
+              .get(`screen.patient.details.${patient?.gender?.toLowerCase()}`)
+              .defaultMessage('--')}
           />
           <DetailsRow title={intl.get('screen.patient.details.dob')} value={patient.birthDate} />
         </DetailsCol>


### PR DESCRIPTION
# [Feature] Display fetus gender

closes #[298]

## Description
Fetus gender should be consistent in patient header as well as in family tab

## Validation

- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
![image](https://user-images.githubusercontent.com/54366437/135342382-048711a1-8c4f-46e0-a0fe-ff48d5bb50ec.png)



## QA
make sure that gender is correctly displayed for fetus AND all the other type of patient (no regression)
## Notification

@ QA, Design ...
