### PR TITLE
fix: CLIN-258 - data extractor + TUs

### DIFF
--- a/client/src/helpers/providers/__tests__/extractor.mocks.ts
+++ b/client/src/helpers/providers/__tests__/extractor.mocks.ts
@@ -1,0 +1,80 @@
+export const emptyData = {
+  practitionersData: {
+    entry: []
+  },
+  patientData: {
+    entry: []
+  },
+}
+
+export const mockPractitioner1 = {
+  resourceType: "Practitioner",
+  id: "1"
+}
+
+export const mockPractitioner2 = {
+  resourceType: "Practitioner",
+  id: "2"
+}
+
+export const mockOrganization1 = {
+  resourceType: "Organization",
+  id: "1"
+}
+
+export const mockPractitionerRole1 = {
+  resourceType: "PractitionerRole",
+  practitioner: {
+    reference: "Practitioner/1"
+  },
+  organization: {
+    reference: "Organization/1"
+  },
+}
+
+export const mockPractitionerRole2 = {
+  resourceType: "PractitionerRole",
+  practitioner: {
+    reference: "Practitioner/2"
+  },
+  organization: {
+    reference: "Organization/2"
+  },
+}
+
+export const mockData = {
+  practitionersData: {
+    entry: [
+      {
+        resource: {
+          entry: [
+            {
+              resource: mockPractitionerRole1
+            },
+            {
+              resource: mockPractitioner1
+            },
+            {
+              resource: mockOrganization1
+            }
+          ]
+        }
+      },
+      {
+        resource: {
+          entry: [
+            {
+              resource: mockPractitionerRole2
+            },
+            {
+              resource: mockPractitioner2
+            },
+          ]
+        }
+      }
+    ]
+  },
+  patientData: {
+    entry: []
+  },
+}

--- a/client/src/helpers/providers/__tests__/extractor.spec.ts
+++ b/client/src/helpers/providers/__tests__/extractor.spec.ts
@@ -1,0 +1,63 @@
+import { DataExtractor } from '../extractor'
+import * as mocks from './extractor.mocks'
+
+describe('DataExtractor', () => {
+
+  test('extractId', () => {
+    const extractor = new DataExtractor(mocks.emptyData)
+    expect(extractor.extractId(undefined)).toEqual(undefined)
+    expect(extractor.extractId('foo')).toEqual(undefined)
+    expect(extractor.extractId('foo/')).toEqual("")
+    expect(extractor.extractId('foo/bar')).toEqual('bar')
+  })
+
+  test('getPractitionerMetaData - nominal', () => {
+    const extractor = new DataExtractor(mocks.mockData)
+    const result = extractor.getPractitionerMetaData("1")
+    expect(result).toEqual({
+      organization: mocks.mockOrganization1,
+      practitioner: mocks.mockPractitioner1,
+    })
+  })
+
+  test('getPractitionerMetaData - missing data', () => {
+    const extractor = new DataExtractor(mocks.mockData)
+    const result = extractor.getPractitionerMetaData("2")
+    expect(result).toEqual({
+      organization: undefined,
+      practitioner: mocks.mockPractitioner2,
+    })
+  })
+
+  test('getPractitionerMetaData - not found', () => {
+    const extractor = new DataExtractor(mocks.mockData)
+    const result = extractor.getPractitionerMetaData("0")
+    expect(result).toEqual(undefined)
+  })
+
+  test('getPractitionerRoleMetaData - nominal', () => {
+    const extractor = new DataExtractor(mocks.mockData)
+    const result = extractor.getPractitionerRoleMetaData("1")
+    expect(result).toEqual({
+      role: mocks.mockPractitionerRole1,
+      organization: mocks.mockOrganization1,
+    })
+  })
+
+  test('getPractitionerRoleMetaData - missing data', () => {
+    const extractor = new DataExtractor(mocks.mockData)
+    const result = extractor.getPractitionerRoleMetaData("2")
+    expect(result).toEqual({
+      role: mocks.mockPractitionerRole2,
+      organization: undefined,
+    })
+  })
+
+  test('getPractitionerRoleMetaData - not found', () => {
+    const extractor = new DataExtractor(mocks.mockData)
+    const result = extractor.getPractitionerRoleMetaData("0")
+    expect(result).toEqual(undefined)
+  })
+
+
+})

--- a/client/src/helpers/providers/__tests__/extractor.spec.ts
+++ b/client/src/helpers/providers/__tests__/extractor.spec.ts
@@ -3,7 +3,7 @@ import * as mocks from './extractor.mocks'
 
 describe('DataExtractor', () => {
 
-  test('extractId', () => {
+  test('extractId - should handle id extraction adequately', () => {
     const extractor = new DataExtractor(mocks.emptyData)
     expect(extractor.extractId(undefined)).toEqual(undefined)
     expect(extractor.extractId('foo')).toEqual(undefined)
@@ -11,7 +11,7 @@ describe('DataExtractor', () => {
     expect(extractor.extractId('foo/bar')).toEqual('bar')
   })
 
-  test('getPractitionerMetaData - nominal', () => {
+  test('getPractitionerMetaData - should find practitioner by id', () => {
     const extractor = new DataExtractor(mocks.mockData)
     const result = extractor.getPractitionerMetaData("1")
     expect(result).toEqual({
@@ -20,7 +20,7 @@ describe('DataExtractor', () => {
     })
   })
 
-  test('getPractitionerMetaData - missing data', () => {
+  test('getPractitionerMetaData - should allow missing organization', () => {
     const extractor = new DataExtractor(mocks.mockData)
     const result = extractor.getPractitionerMetaData("2")
     expect(result).toEqual({
@@ -29,13 +29,13 @@ describe('DataExtractor', () => {
     })
   })
 
-  test('getPractitionerMetaData - not found', () => {
+  test('getPractitionerMetaData - should return undefined if id not found', () => {
     const extractor = new DataExtractor(mocks.mockData)
     const result = extractor.getPractitionerMetaData("0")
     expect(result).toEqual(undefined)
   })
 
-  test('getPractitionerRoleMetaData - nominal', () => {
+  test('getPractitionerRoleMetaData - should find practitioner by id', () => {
     const extractor = new DataExtractor(mocks.mockData)
     const result = extractor.getPractitionerRoleMetaData("1")
     expect(result).toEqual({
@@ -44,7 +44,7 @@ describe('DataExtractor', () => {
     })
   })
 
-  test('getPractitionerRoleMetaData - missing data', () => {
+  test('getPractitionerRoleMetaData - should allow missing organization', () => {
     const extractor = new DataExtractor(mocks.mockData)
     const result = extractor.getPractitionerRoleMetaData("2")
     expect(result).toEqual({
@@ -53,7 +53,7 @@ describe('DataExtractor', () => {
     })
   })
 
-  test('getPractitionerRoleMetaData - not found', () => {
+  test('getPractitionerRoleMetaData - should return undefined if id not found', () => {
     const extractor = new DataExtractor(mocks.mockData)
     const result = extractor.getPractitionerRoleMetaData("0")
     expect(result).toEqual(undefined)

--- a/client/src/helpers/providers/extractor.ts
+++ b/client/src/helpers/providers/extractor.ts
@@ -60,13 +60,11 @@ export class DataExtractor {
         const practitioner = this.maybeExtractResource<Practitioner>(resource, 'Practitioner')
         const organization = this.maybeExtractResource<Organization>(resource, 'Organization')
 
-        if (practitioner) {
-          if (practitioner.id === id) {
-            return {
-              organization: organization,
-              practitioner: practitioner,
-            };
-          }
+        if (practitioner && practitioner.id === id) {
+          return {
+            organization: organization,
+            practitioner: practitioner,
+          };
         }
       }
     }
@@ -82,13 +80,11 @@ export class DataExtractor {
         const practitionerRole = this.maybeExtractResource<PractitionerRole>(resource, 'PractitionerRole')
         const organization = this.maybeExtractResource<Organization>(resource, 'Organization')
 
-        if (practitionerRole) {
-          if (this.extractId(get(practitionerRole, 'practitioner.reference')) === id) {
-            return {
-              role: practitionerRole,
-              organization: organization,
-            };
-          }
+        if (practitionerRole && this.extractId(get(practitionerRole, 'practitioner.reference')) === id) {
+          return {
+            role: practitionerRole,
+            organization: organization,
+          };
         }
       }
     }


### PR DESCRIPTION
# BUG

closes CLIN-258

## Description

Practitioner tooltip (again) crash the front-end. 

This fix may have good impact on other known data missing/invalid issues.

## Validation

- [x] Test Coverage
- [ ] QA

## QA

- sign-in any user
- go to the Prescriptions of Patient RAMQ: TEST199001012
- Mouse hover 'Médecin responsable' tooltip
