### PR TITLE
fix: #296 make sure that member status is displayed

### DIFF
--- a/client/src/components/screens/Patient/components/FamilyTab/components/FamilyTable.tsx
+++ b/client/src/components/screens/Patient/components/FamilyTab/components/FamilyTable.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import { useSelector } from 'react-redux';
 import { DownOutlined } from '@ant-design/icons';
-import { updateParentStatusInFamily } from 'actions/patient';
 import { Button, Card, Dropdown, Table, Tooltip } from 'antd';
 import { ColumnType } from 'antd/lib/table';
 import { isFetusOnly } from 'helpers/fhir/familyMemberHelper';
@@ -92,13 +91,7 @@ const FamilyTable = ({
         if (record.member.isProband) {
           return '--';
         }
-        return (
-          <StatusCell
-            memberCode={record.member.code}
-            memberId={record.member.id}
-            updateParentStatusInFamily={updateParentStatusInFamily}
-          />
-        );
+        return <StatusCell memberCode={record.member.code} memberId={record.member.id} />;
       },
       title: intl.get('screen.patient.details.family.table.status'),
       width: 160,

--- a/client/src/components/screens/Patient/components/FamilyTab/components/StatusCell.tsx
+++ b/client/src/components/screens/Patient/components/FamilyTab/components/StatusCell.tsx
@@ -1,37 +1,44 @@
-import { Select } from 'antd';
 import React from 'react';
-import { useDispatch } from 'react-redux';
 import intl from 'react-intl-universal';
-import { Action } from 'redux';
-import { GroupMemberStatusCode } from '../../../../../../helpers/fhir/patientHelper';
+import { useDispatch, useSelector } from 'react-redux';
+import { updateParentStatusInFamily } from 'actions/patient';
+import { Select } from 'antd';
+import { GroupMemberStatusCode } from 'helpers/fhir/patientHelper';
+import { State } from 'reducers';
+
+import { GroupMemberStatusCodes } from 'store/GroupTypes';
 
 type Props = {
   memberCode: GroupMemberStatusCode;
-  updateParentStatusInFamily: (id: string, status: GroupMemberStatusCode) => Action
   memberId: string;
-}
+};
 
-const StatusCell = ({
-  memberId, memberCode, updateParentStatusInFamily,
-}: Props) => {
+const StatusCell = ({ memberCode, memberId }: Props): React.ReactElement => {
   const dispatch = useDispatch();
+  const idsOfParentUpdatingStatuses = useSelector(
+    (state: State) => state.patient.idsOfParentUpdatingStatuses,
+  );
+
+  const isUpdatingStatus = idsOfParentUpdatingStatuses.includes(memberId);
 
   return (
     <Select
       className="family-tab__details__table__status"
-      value={memberCode}
+      defaultValue={memberCode}
+      disabled={isUpdatingStatus}
+      loading={isUpdatingStatus}
       onChange={(newStatus) => {
         dispatch(updateParentStatusInFamily(memberId, newStatus));
       }}
     >
-      <Select.Option value="UNF">
-        { intl.get('screen.patient.details.family.modal.status.no') }
+      <Select.Option value={GroupMemberStatusCodes.unaffected}>
+        {intl.get('screen.patient.details.family.modal.status.no')}
       </Select.Option>
-      <Select.Option value="AFF">
-        { intl.get('screen.patient.details.family.modal.status.yes') }
+      <Select.Option value={GroupMemberStatusCodes.affected}>
+        {intl.get('screen.patient.details.family.modal.status.yes')}
       </Select.Option>
-      <Select.Option value="UNK">
-        { intl.get('screen.patient.details.family.modal.status.unknown') }
+      <Select.Option value={GroupMemberStatusCodes.unknown}>
+        {intl.get('screen.patient.details.family.modal.status.unknown')}
       </Select.Option>
     </Select>
   );

--- a/client/src/components/screens/Patient/components/FamilyTab/tests/mockData.ts
+++ b/client/src/components/screens/Patient/components/FamilyTab/tests/mockData.ts
@@ -35,6 +35,7 @@ export const patientProbandSubState = {
         relationCode: 'FTH',
       },
     ],
+    idsOfParentUpdatingStatuses: [],
     patient: {
       original: {
         identifier: [
@@ -116,6 +117,7 @@ export const patientNotProbandSubState = {
         relationCode: 'FTH',
       },
     ],
+    idsOfParentUpdatingStatuses: [],
     patient: {
       original: {
         active: true,

--- a/client/src/helpers/fhir/familyMemberHelper.ts
+++ b/client/src/helpers/fhir/familyMemberHelper.ts
@@ -1,6 +1,6 @@
 import { FamilyMember, FamilyMembersResponse, FamilyMemberType } from 'store/FamilyMemberTypes';
 
-import { getRAMQValue } from './patientHelper';
+import { getRAMQValue, GroupMemberStatusCode } from './patientHelper';
 import { Extension, Patient } from './types';
 
 const FAMILY_RELATION_EXT_URL = 'http://fhir.cqgc.ferlab.bio/StructureDefinition/family-relation';
@@ -59,6 +59,7 @@ export const parseFamilyMember = (
     const familyPatientId = mainEntry?.resource?.id || '';
     return {
       birthDate: mainEntry?.resource?.birthDate || '',
+      code: rawFamilyMember.entry?.groupMemberStatusCode,
       firstName: mainEntry?.resource?.name[0]?.given[0] || '',
       gender: mainEntry?.resource?.gender || '',
       id: familyPatientId,
@@ -82,11 +83,8 @@ export const isFetusOnly = (fm: FamilyMember): boolean =>
 export const isNaturalMotherOfFetus = (fm: FamilyMember): boolean =>
   !!fm && !!fm.relationCode && FamilyMemberType.NATURAL_MOTHER_OF_FETUS === fm.relationCode;
 
-
 export const findNaturalMotherOfFetus = (members: FamilyMember[]): FamilyMember | null =>
-  (members || []).find(
-    (fm) => isNaturalMotherOfFetus(fm),
-  ) || null;
+  (members || []).find((fm) => isNaturalMotherOfFetus(fm)) || null;
 
 export const hasAtLeastOneMotherInMembers = (members: FamilyMember[]): boolean =>
   (members || []).some((fm) => fm.relationCode && CODES_FOR_MOTHER.includes(fm.relationCode));
@@ -101,3 +99,16 @@ export const parentTypeToGender = {
 
 export const hasAtLeastOneOtherMember = (patientId: string, members: FamilyMember[]): boolean =>
   (members || []).some((member) => member.id !== patientId);
+
+export const addNewMemberStatusToFamilyMember = ({
+  memberIdToUpdate,
+  members,
+  newStatus,
+}: {
+  members: FamilyMember[];
+  newStatus: GroupMemberStatusCode;
+  memberIdToUpdate: string;
+}): FamilyMember[] =>
+  (members || []).map((member) =>
+    member.id === memberIdToUpdate ? { ...member, code: newStatus } : { ...member },
+  );

--- a/client/src/reducers/patient.ts
+++ b/client/src/reducers/patient.ts
@@ -1,4 +1,5 @@
 import intl from 'react-intl-universal';
+import * as actions from 'actions/type';
 import { message } from 'antd';
 import {
   addNewMemberStatusToFamilyMember,
@@ -22,7 +23,9 @@ import { ServiceRequestProvider } from 'helpers/providers/service-request';
 import { produce } from 'immer';
 import get from 'lodash/get';
 
-import * as actions from '../actions/type';
+import { FamilyMember } from 'store/FamilyMemberTypes';
+import { Observations } from 'store/ObservationTypes';
+
 import {
   ClinicalObservation,
   ConsultationSummary,
@@ -30,8 +33,6 @@ import {
   ParsedPatientData,
   Prescription,
 } from '../helpers/providers/types';
-import { FamilyMember } from '../store/FamilyMemberTypes';
-import { Observations } from '../store/ObservationTypes';
 
 const addParentId = (originalIds: string[], idToAdd: string) => [...originalIds, idToAdd];
 const removeParentId = (originalIds: string[], idToRemove: string) =>
@@ -182,7 +183,7 @@ const reducer = (state: PatientState = initialState, action: Action) =>
         );
         draft.family = addNewMemberStatusToFamilyMember({
           memberIdToUpdate: parentId,
-          members: (draft.family as FamilyMember[]),
+          members: draft.family as FamilyMember[],
           newStatus: status,
         });
         break;

--- a/client/src/sagas/patient.js
+++ b/client/src/sagas/patient.js
@@ -30,21 +30,57 @@ const getIdsFromPatient = (data) => {
   return ids;
 };
 
+const buildPtIdToGrMemStatusCode = (rawResponse) => {
+  if (!rawResponse || rawResponse.length === 0) {
+    return {};
+  }
+  return rawResponse.reduce((accumulator, entityAndExtension) => {
+    const ref = entityAndExtension?.entity?.reference || '';
+    const splitRef = ref.split('/');
+    const indexOfId = 1;
+    const id = splitRef[indexOfId];
+    if (!id) {
+      return accumulator;
+    }
+    const memberStatusExtension = (entityAndExtension?.extension || []).find((ext) =>
+      (ext?.url || '').endsWith('/group-member-status'),
+    );
+    const code = memberStatusExtension?.valueCoding?.code;
+    if (!code) {
+      return accumulator;
+    }
+    return {
+      ...accumulator,
+      [id]: code,
+    };
+  }, {});
+};
+
 const getFamily = async (patientDataResponse) => {
-  const familyMemberIds = getFamilyMembersFromPatientDataResponse(patientDataResponse).map(
+  const familyMembersFromPatientResponse =
+    getFamilyMembersFromPatientDataResponse(patientDataResponse);
+
+  const familyMemberIds = familyMembersFromPatientResponse.map(
     (member) => member.entity.reference.split('/')[1],
   );
 
   if (familyMemberIds.length === 0) {
     return null;
   }
+
+  const ptIdToGrMemStatusCode = buildPtIdToGrMemStatusCode(familyMembersFromPatientResponse);
+
   const response = await Api.getPatientDataByIds(familyMemberIds, false);
 
-  return get(response, 'payload.data.entry', []).map((entry) => ({
-    entry: {
-      resource: entry.resource,
-    },
-  }));
+  return get(response, 'payload.data.entry', []).map((entry) => {
+    const guessedPatientId = entry?.resource?.entry[0]?.resource?.id;
+    return {
+      entry: {
+        groupMemberStatusCode: ptIdToGrMemStatusCode[guessedPatientId],
+        resource: entry.resource,
+      },
+    };
+  });
 };
 
 function* updateParentGroup(parentId, newGroupId) {
@@ -323,19 +359,17 @@ function* removeParent(action) {
 }
 
 function* updateParentStatus(action) {
+  const { parentId, status } = action.payload;
   try {
-    const { parentId, status } = action.payload;
     const parsedPatient = yield select((state) => state.patient.patient.parsed);
-
     yield Api.addOrUpdatePatientToGroup(parsedPatient.familyId, parentId, status);
-
     yield put({
       payload: { parentId, status },
       type: actions.PATIENT_UPDATE_PARENT_STATUS_SUCCEEDED,
     });
   } catch (error) {
     console.error('updateParentStatus', error);
-    yield put({ payload: error, type: actions.PATIENT_UPDATE_PARENT_STATUS_FAILED });
+    yield put({ payload: { error, parentId }, type: actions.PATIENT_UPDATE_PARENT_STATUS_FAILED });
   }
 }
 

--- a/client/src/sagas/patient.js
+++ b/client/src/sagas/patient.js
@@ -30,31 +30,28 @@ const getIdsFromPatient = (data) => {
   return ids;
 };
 
-const buildPtIdToGrMemStatusCode = (rawResponse) => {
-  if (!rawResponse || rawResponse.length === 0) {
-    return {};
-  }
-  return rawResponse.reduce((accumulator, entityAndExtension) => {
-    const ref = entityAndExtension?.entity?.reference || '';
-    const splitRef = ref.split('/');
-    const indexOfId = 1;
-    const id = splitRef[indexOfId];
-    if (!id) {
-      return accumulator;
-    }
-    const memberStatusExtension = (entityAndExtension?.extension || []).find((ext) =>
-      (ext?.url || '').endsWith('/group-member-status'),
-    );
-    const code = memberStatusExtension?.valueCoding?.code;
-    if (!code) {
-      return accumulator;
-    }
-    return {
-      ...accumulator,
-      [id]: code,
-    };
-  }, {});
-};
+const buildPtIdToGrMemStatusCode = (rawResponse) =>
+  !rawResponse || rawResponse.length === 0
+    ? {}
+    : rawResponse.reduce((accumulator, entityAndExtension) => {
+        const ref = entityAndExtension?.entity?.reference || '';
+        const splitRef = ref.split('/');
+        const indexOfId = 1;
+        const id = splitRef[indexOfId];
+        if (!id) {
+          return accumulator;
+        }
+        const code = (entityAndExtension?.extension || []).find((ext) =>
+          (ext?.url || '').endsWith('/group-member-status'),
+        )?.valueCoding?.code;
+        if (!code) {
+          return accumulator;
+        }
+        return {
+          ...accumulator,
+          [id]: code,
+        };
+      }, {});
 
 const getFamily = async (patientDataResponse) => {
   const familyMembersFromPatientResponse =

--- a/client/src/store/FamilyMemberTypes.ts
+++ b/client/src/store/FamilyMemberTypes.ts
@@ -18,17 +18,18 @@ export type FamilyMember = {
   ramq?: string;
   birthDate?: string;
   gender?: 'male' | 'female';
-  code: GroupMemberStatusCode
-  relationCode?: string
+  code: GroupMemberStatusCode;
+  relationCode?: string;
   isFetus: boolean;
-}
+};
 
 export type FamilyMembersResponse = {
   entry: {
     resource: {
       id: string;
-      entry: {fullUrl: string; resource: Patient}[];
-      [index: string]: any
-    }
-  }
-}
+      entry: { fullUrl: string; resource: Patient }[];
+      [index: string]: any;
+    };
+    groupMemberStatusCode?: GroupMemberStatusCode;
+  };
+};

--- a/client/src/store/GroupTypes.ts
+++ b/client/src/store/GroupTypes.ts
@@ -1,0 +1,5 @@
+export enum GroupMemberStatusCodes {
+  affected = 'AFF',
+  unaffected = 'UNF',
+  unknown = 'UNK',
+}


### PR DESCRIPTION
# [BUG] [Display parent status correctly]

closes #[296]

## Description
a change of status was not reflected in the displayed data

Critères de succès
status must always be consistent.

## Validation

- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
![image](https://user-images.githubusercontent.com/54366437/135920520-ff64658a-8d87-4701-89d4-4d7232ad48b6.png)



## QA
make sure that when one changes the status that it updates, even after a refresh
