### PR TITLE
fix: #301 make sure mother of fetus is not proband

### DIFF
--- a/client/src/helpers/fhir/api/CreatePatient.ts
+++ b/client/src/helpers/fhir/api/CreatePatient.ts
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
 import set from 'lodash/set';
+
 import httpClient from '../../http-client';
 import { BundleBuilder } from '../builder/BundleBuilder';
 import { FamilyGroupBuilder, FamilyStructure } from '../builder/FamilyGroupBuilder';
@@ -37,10 +38,10 @@ export const createPatient = async (patient: Patient): Promise<CreatePatientResp
 
   const members = get(bundle, 'entry[1].resource.member', []);
   members.push({
-    extension: [generateGroupStatus('AFF')],
     entity: {
       reference: get(bundle, 'entry[0].fullUrl'),
     },
+    extension: [generateGroupStatus('AFF')],
   });
 
   patient.extension.push({
@@ -63,8 +64,8 @@ export const createPatient = async (patient: Patient): Promise<CreatePatientResp
   }];
 
   return {
-    patient: p,
     familyGroup: fg,
+    patient: p,
   };
 };
 
@@ -82,6 +83,7 @@ export const createPatientFetus = async (patient: Patient): Promise<CreatePatien
   patientFetus.extension.find((ext) => ext.url === EXTENSION_IS_PROBAND)!.valueBoolean = true;
   patientFetus.extension.find((ext) => ext.url === EXTENSION_IS_FETUS)!.valueBoolean = true;
 
+  patientParent.extension.find((ext) => ext.url === EXTENSION_IS_PROBAND)!.valueBoolean = false;
   patientParent.gender = FEMALE_GENDER;
 
   const familyGroup = new FamilyGroupBuilder()
@@ -108,7 +110,6 @@ export const createPatientFetus = async (patient: Patient): Promise<CreatePatien
 
   // Adds reference to the fetus
   get(bundle, 'entry[0].resource.extension').push({
-    url: 'http://fhir.cqgc.ferlab.bio/StructureDefinition/family-relation',
     extension: [
       {
         url: 'subject',
@@ -127,11 +128,11 @@ export const createPatientFetus = async (patient: Patient): Promise<CreatePatien
         },
       },
     ],
+    url: 'http://fhir.cqgc.ferlab.bio/StructureDefinition/family-relation',
   });
 
   // Adds reference to the parent
   get(bundle, 'entry[1].resource.extension').push({
-    url: 'http://fhir.cqgc.ferlab.bio/StructureDefinition/family-relation',
     extension: [
       {
         url: 'subject',
@@ -150,6 +151,7 @@ export const createPatientFetus = async (patient: Patient): Promise<CreatePatien
         },
       },
     ],
+    url: 'http://fhir.cqgc.ferlab.bio/StructureDefinition/family-relation',
   });
 
   if (isNewPatient) {
@@ -170,16 +172,16 @@ export const createPatientFetus = async (patient: Patient): Promise<CreatePatien
 
   set(bundle, 'entry[2].resource.member', [
     {
-      extension: [generateGroupStatus('UNF')],
       entity: {
         reference: get(bundle, 'entry[0].fullUrl'),
       },
+      extension: [generateGroupStatus('UNF')],
     },
     {
-      extension: [generateGroupStatus('AFF')],
       entity: {
         reference: get(bundle, 'entry[1].fullUrl'),
       },
+      extension: [generateGroupStatus('AFF')],
     },
   ]);
   const response = await httpClient.secureClinAxios.post(`${window.CLIN.fhirBaseUrl}/?id=${bundleId}`, bundle);
@@ -201,8 +203,8 @@ export const createPatientFetus = async (patient: Patient): Promise<CreatePatien
   }];
 
   return {
+    familyGroup: fg,
     patient: p,
     patientFetus: pf,
-    familyGroup: fg,
   };
 };


### PR DESCRIPTION
# [BUG] [Make sure mother of fetus is NOT proband]

closes #[301]

## Description
When adding a prescription to a fetus with a mother that **already** exists the mother must not retain the proband status.
Critères de succès

## Validation

- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
![image](https://user-images.githubusercontent.com/54366437/136261486-443732d0-47b2-488b-b364-44115d8ef8e8.png)

## QA
Create a new mother, to make sure data is ok. Then, create a prescription for a fetus linking that mother to it.
![image](https://user-images.githubusercontent.com/54366437/136261618-18c98ec5-2cb0-4d6b-a249-dd410f32ccba.png)

