### PR TITLE
fix: #345 make sure that correct url is called for variant details

### DIFF
--- a/client/src/sagas/router.js
+++ b/client/src/sagas/router.js
@@ -12,7 +12,7 @@ import {
 function* navigateToVariantDetailsScreen(action) {
   try {
     const { tab, uid } = action.payload;
-    let url = Routes.getPatientPath(uid);
+    let url = Routes.getVariantPath(uid);
     if (tab) { url += `/#${tab}`; }
 
     yield put(push(url));


### PR DESCRIPTION
# [BUG [Wrong url for variant details]

closes #[345]

## Description
Unable to get to the variant entity page when clicking on a variant.
## Validation
when clicking on a variant in a patient page we should be able to get to the entity page
![image](https://user-images.githubusercontent.com/54366437/137770055-9bffbca2-bebc-4741-bb13-344ace0387d3.png)

- [ ] Test Coverage
- [ ] QA Done
- [ ] Design/UI Approved from design

## Screenshot
![image](https://user-images.githubusercontent.com/54366437/137769895-41167485-1d92-40e4-8a35-e796a06aa200.png)



## QA

Étapes de validation
Url (storybook, ...)
...

## Notification

@ QA, Design ...
