### PR TITLE
feat: #359 delete solo group of parent that was just added

### DIFF
--- a/client/src/actions/patient.ts
+++ b/client/src/actions/patient.ts
@@ -63,11 +63,12 @@ type familyActionCb = ((isSuccess: boolean) => Promise<void> | void) | undefined
 
 export const addParentToFamily: Action = (
   parentId: string,
+  familyId: string,
   parentType: FamilyMemberType,
   status: GroupMemberStatus,
   callback: familyActionCb,
 ) => ({
-  payload: { callback, parentId, parentType, status },
+  payload: { callback, parentId, parentType, familyId, status },
   type: actions.PATIENT_ADD_PARENT_REQUESTED,
 });
 

--- a/client/src/components/screens/Patient/components/FamilyTab/components/AddParentModal.tsx
+++ b/client/src/components/screens/Patient/components/FamilyTab/components/AddParentModal.tsx
@@ -88,7 +88,15 @@ const AddParentModal = ({ onClose, parentType }: Props): React.ReactElement => {
         : message.error(intl.get(status.messageKey));
       cleanUpBeforeClosing();
     };
-    dispatch(addParentToFamily(selectedPatient?.id, parentType, affectedStatus!, callback));
+    dispatch(
+      addParentToFamily(
+        selectedPatient?.id,
+        selectedPatient?.familyId,
+        parentType,
+        affectedStatus!,
+        callback,
+      ),
+    );
   }
 
   const updateStatus = (event: RadioChangeEvent) => {

--- a/client/src/helpers/api.ts
+++ b/client/src/helpers/api.ts
@@ -53,7 +53,14 @@ const getPatientDataById = (id: string) =>
     .then(successCallback)
     .catch(errorCallback);
 
-const getGroupById = (id: string) =>
+const getGroupById = (
+  id: string,
+): Promise<{
+  payload?: {
+    data: Bundle;
+  };
+  error?: AnyError;
+}> =>
   Http.secureClinAxios
     .get(`${window.CLIN.fhirBaseUrl}/Group?_id=${id}`)
     .then(successCallback)
@@ -69,6 +76,12 @@ const getGroupByMemberId = (
 }> =>
   Http.secureClinAxios
     .get(`${window.CLIN.fhirBaseUrl}/Group?member=${id}`)
+    .then(successCallback)
+    .catch(errorCallback);
+
+const deleteGroup = (groupId: string) =>
+  Http.secureClinAxios
+    .delete(`${window.CLIN.fhirBaseUrl}/Group/${groupId}`)
     .then(successCallback)
     .catch(errorCallback);
 
@@ -351,8 +364,8 @@ const updateServiceRequestStatus = async (
     ...serviceRequest,
     performer: [
       {
-        reference: `PractitionerRole/${user.practitionerData.practitionerRole.id}`
-      }
+        reference: `PractitionerRole/${user.practitionerData.practitionerRole.id}`,
+      },
     ],
     extension,
     note: notes,
@@ -497,6 +510,7 @@ export default {
   getGroupById,
   getPatientById,
   getGroupByMemberId,
+  deleteGroup,
   getPatientDataByIds,
   getPatientsByAutoComplete,
   getPatientsGenderAndPosition,

--- a/client/src/helpers/fhir/familyMemberHelper.ts
+++ b/client/src/helpers/fhir/familyMemberHelper.ts
@@ -116,22 +116,18 @@ export const addNewMemberStatusToFamilyMember = ({
 
 export const isMemberProband = (fm: FamilyMember): boolean => !!fm && fm.isProband;
 
-export const isMemberAloneAccordingToGroupBundle = (
+export const isMemberAloneInGroupBundle = (
   memberId: string,
+  groupId: string,
   groupBundle: Bundle,
 ): boolean => {
-  const groupResources =
-    (groupBundle?.entry || []).map((entry) => ({ ...entry.resource } as FamilyGroup)) || [];
-  /*
-   * Legacy (zombie groups):
-   * a patient can have multiple groups associated to him/her at the time of this writing.
-   * As long as this situation remains, all we need to check is that the member is alone
-   * in all of them. This check should be valid if the zombie issue is resolved.
-   * */
-  const membersFromAllGroups = groupResources
-    .map((resource) => resource.member || [])
-    .flat() as BackboneElement[];
-  return membersFromAllGroups.every(
+  const foundGroupResource = (groupBundle?.entry || []).find((entry) =>
+    entry.fullUrl?.endsWith(`/Group/${groupId}`),
+  )?.resource as FamilyGroup;
+  if (!foundGroupResource) {
+    return false;
+  }
+  return !!foundGroupResource?.member?.every(
     (member) => member?.entity?.reference === `Patient/${memberId}`,
   );
 };


### PR DESCRIPTION
# [Feat] [Delete solo group when a parent was added]

closes #[359]

## Description
When a patient is promoted as parent his/her current family (himself/herself only) must be deleted.


## Screenshot
![image](https://user-images.githubusercontent.com/54366437/139336140-2a3ddc9c-13b2-4e42-b110-905778aa0587.png)


## QA
Check that the UI works as expected. Check in fhir that data is consistent 
