### PR TITLE
fix: clin-414 update removed patient with new group

### DIFF
--- a/client/src/helpers/fhir/patientHelper.spec.ts
+++ b/client/src/helpers/fhir/patientHelper.spec.ts
@@ -1,8 +1,14 @@
 import moment from 'moment';
-import { getDetailsFromRamq, RamqDetails } from './patientHelper';
+
+import {
+  getDetailsFromRamq,
+  makeExtensionProband,
+  RamqDetails,
+  replaceExtensionFamilyId,
+} from './patientHelper';
 
 describe('Helper: PatientHelper', () => {
-  describe('Function: getDetailsFromRamq', () => {
+  describe(`Function: ${getDetailsFromRamq.name}`, () => {
     test('should return null from invalid ramq', () => {
       expect(getDetailsFromRamq('')).toBeNull();
       expect(getDetailsFromRamq('toto')).toBeNull();
@@ -15,32 +21,32 @@ describe('Helper: PatientHelper', () => {
 
     test('should return valid RamqDetails from valid ramq', () => {
       expect(getDetailsFromRamq('SMIM20010101')).toEqual({
-        startFirstname: 'M',
-        startLastname: 'Smi',
         birthDate: moment('2020-01-01').toDate(),
         sex: 'male',
+        startFirstname: 'M',
+        startLastname: 'Smi',
       } as RamqDetails);
 
       expect(getDetailsFromRamq('SMIS19512301')).toEqual({
-        startFirstname: 'S',
-        startLastname: 'Smi',
         birthDate: moment('2019-01-23').toDate(),
         sex: 'female',
+        startFirstname: 'S',
+        startLastname: 'Smi',
       } as RamqDetails);
     });
 
     test('should handle older dates', () => {
       expect(getDetailsFromRamq('SMIS75512301')).toEqual({
-        startFirstname: 'S',
-        startLastname: 'Smi',
         birthDate: moment('1975-01-23').toDate(),
         sex: 'female',
-      } as RamqDetails);
-      expect(getDetailsFromRamq('SMIS60512301')).toEqual({
         startFirstname: 'S',
         startLastname: 'Smi',
+      } as RamqDetails);
+      expect(getDetailsFromRamq('SMIS60512301')).toEqual({
         birthDate: moment('1960-01-23').toDate(),
         sex: 'female',
+        startFirstname: 'S',
+        startLastname: 'Smi',
       } as RamqDetails);
     });
 
@@ -48,20 +54,54 @@ describe('Helper: PatientHelper', () => {
       const nextYear = moment().add(1, 'year');
       const expectedYear = nextYear.subtract(100, 'years');
       expect(getDetailsFromRamq(`SMIS${nextYear.format('YY')}512301`)).toEqual({
-        startFirstname: 'S',
-        startLastname: 'Smi',
         birthDate: moment(`${expectedYear.format('YYYY')}-01-23`).toDate(),
         sex: 'female',
+        startFirstname: 'S',
+        startLastname: 'Smi',
       } as RamqDetails);
     });
 
     test('should handle 2001', () => {
       expect(getDetailsFromRamq('SMIS01512301')).toEqual({
-        startFirstname: 'S',
-        startLastname: 'Smi',
         birthDate: moment('2001-01-23').toDate(),
         sex: 'female',
+        startFirstname: 'S',
+        startLastname: 'Smi',
       } as RamqDetails);
+    });
+  });
+  describe(`Function: ${makeExtensionProband.name}`, () => {
+    test('should make an extension positively proband', () => {
+      const originalExtensions = [
+        { url: 'http://fhir.cqgc.ferlab.bio/StructureDefinition/is-proband', valueBoolean: false },
+      ];
+      const expectedExtensions = [
+        { url: 'http://fhir.cqgc.ferlab.bio/StructureDefinition/is-proband', valueBoolean: true },
+      ];
+
+      const updatedExtensionsToIsProband = makeExtensionProband(originalExtensions);
+      expect(updatedExtensionsToIsProband).toEqual(expectedExtensions);
+      expect(Object.is(updatedExtensionsToIsProband, originalExtensions)).toBeFalsy();
+    });
+  });
+  describe(`Function: ${replaceExtensionFamilyId.name}`, () => {
+    test('should replace the old family id in the extension with a new family id', () => {
+      const originalExtensions = [
+        {
+          url: 'http://fhir.cqgc.ferlab.bio/StructureDefinition/family-id',
+          valueReference: { reference: 'Group/1' },
+        },
+      ];
+      const expectedExtensions = [
+        {
+          url: 'http://fhir.cqgc.ferlab.bio/StructureDefinition/family-id',
+          valueReference: { reference: 'Group/2' },
+        },
+      ];
+
+      const replacedExtension = replaceExtensionFamilyId(originalExtensions, '1', '2');
+      expect(replacedExtension).toEqual(expectedExtensions);
+      expect(Object.is(replacedExtension, originalExtensions)).toBeFalsy();
     });
   });
 });

--- a/client/src/store/urls.ts
+++ b/client/src/store/urls.ts
@@ -2,5 +2,6 @@ export enum ExtensionUrls {
   FamilyRelation = 'http://fhir.cqgc.ferlab.bio/StructureDefinition/family-relation',
   FamilyId = 'http://fhir.cqgc.ferlab.bio/StructureDefinition/family-id',
   ResidentSupervisor = 'http://fhir.cqgc.ferlab.bio/StructureDefinition/resident-supervisor',
-  AgeAtEvent = 'http://fhir.cqgc.ferlab.bio/StructureDefinition/age-at-event'
+  AgeAtEvent = 'http://fhir.cqgc.ferlab.bio/StructureDefinition/age-at-event',
+  IsProband = 'http://fhir.cqgc.ferlab.bio/StructureDefinition/is-proband',
 }


### PR DESCRIPTION
# [BUG] [ajust group reference when removing a patient from his/her family]

closes #[414]

## Description
When removing a patient from a group (family), make sure that this group is not referenced in the patient's references.

## Screenshot
![image](https://user-images.githubusercontent.com/54366437/140995568-3f43dc94-4c9d-4d56-9546-31dd4b7fddfd.png)


## QA
Check in the UI that all is good + check data in fhir
...

## Notification

@ QA, Design ...
