### PR TITLE
clin-540: Afficher analyse dans page patient

### DIFF
--- a/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescriptions.tsx
+++ b/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescriptions.tsx
@@ -329,7 +329,7 @@ const Prescriptions = ({ clinicalImpressions, prescriptions }: Props): React.Rea
                   </DetailsRow>
                   <div className={`${tabDetailsCNPrefix}__offsetSection`}>
                     <DetailsRow label={intl.get('screen.patient.details.prescription.tests')}>
-                      <Typography.Title className={`${tabDetailsCNPrefix}__test`} level={4} >{ intl.get(prescription.test) || DEFAULT_VALUE }</Typography.Title>
+                      <Typography.Title className={`${tabDetailsCNPrefix}__test`} level={4} >{ prescription.test || DEFAULT_VALUE }</Typography.Title>
                     </DetailsRow>        
                     <DetailsRow label={intl.get('screen.patient.details.prescription.comments')}>
                       { prescription.note || DEFAULT_VALUE }

--- a/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescriptions.tsx
+++ b/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescriptions.tsx
@@ -125,7 +125,7 @@ const getPrescriptionKey = (prescriptions: Prescription[], openedPrescriptionId:
   return get(prescription, 'id');
 };
 
-const getAnalysisTraduction = (display: string, concepts: Concept[], lang:string ) => {
+const translateAnalysis = (display: string, concepts: Concept[], lang:string ) => {
   const concept = concepts.find((c)=> c.display === display)
   if(concept){
     const designation = concept.designation.find(d => d.language === lang);
@@ -346,9 +346,7 @@ const Prescriptions = ({ clinicalImpressions, prescriptions }: Props): React.Rea
                   <div className={`${tabDetailsCNPrefix}__offsetSection`}>
                     <DetailsRow label={intl.get('screen.patient.details.prescription.tests')}>
                       <Typography.Title className={`${tabDetailsCNPrefix}__test`} level={4} >
-                        { serviceRequestCodeState.length >0 
-                          ? getAnalysisTraduction(prescription.test, serviceRequestCodeState, lang) 
-                          : DEFAULT_VALUE }
+                        { translateAnalysis(prescription.test, serviceRequestCodeState, lang) }
                       </Typography.Title>
                     </DetailsRow>        
                     <DetailsRow label={intl.get('screen.patient.details.prescription.comments')}>

--- a/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescriptions.tsx
+++ b/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescriptions.tsx
@@ -23,6 +23,7 @@ import {
 } from 'antd';
 import { ClinicalImpression, Observation, Reference } from 'helpers/fhir/types';
 import { ConsultationSummary, FamilyObservation, PractitionerData, Prescription, PrescriptionStatus } from 'helpers/providers/types';
+import { findLocalDesignationIfExists } from 'helpers/ServiceRequestCode';
 import get from 'lodash/get';
 import moment from 'moment';
 import { State } from 'reducers';
@@ -125,13 +126,9 @@ const getPrescriptionKey = (prescriptions: Prescription[], openedPrescriptionId:
   return get(prescription, 'id');
 };
 
-const translateAnalysis = (display: string, concepts: Concept[], lang:string ) => {
-  const concept = concepts.find((c)=> c.display === display)
-  if(concept){
-    const designation = concept.designation.find(d => d.language === lang);
-    return designation ? designation.value : display;
-  }
-  return DEFAULT_VALUE
+const translateAnalysis = (testName: string, concepts: Concept[], lang:'fr' | 'en' ) => {
+  const concept = concepts.find((c)=> c.display === testName)
+  return findLocalDesignationIfExists(concept, lang) || DEFAULT_VALUE
 }
 
 const Prescriptions = ({ clinicalImpressions, prescriptions }: Props): React.ReactElement => {

--- a/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescriptions.tsx
+++ b/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescriptions.tsx
@@ -23,7 +23,7 @@ import {
 } from 'antd';
 import { ClinicalImpression, Observation, Reference } from 'helpers/fhir/types';
 import { ConsultationSummary, FamilyObservation, PractitionerData, Prescription, PrescriptionStatus } from 'helpers/providers/types';
-import { findLocalDesignationIfExists } from 'helpers/ServiceRequestCode';
+import { translateAnalysis } from 'helpers/ServiceRequestCode';
 import get from 'lodash/get';
 import moment from 'moment';
 import { State } from 'reducers';
@@ -125,11 +125,6 @@ const getPrescriptionKey = (prescriptions: Prescription[], openedPrescriptionId:
   const prescription = prescriptions.find((p) => p.id === openedPrescriptionId);
   return get(prescription, 'id');
 };
-
-const translateAnalysis = (testName: string, concepts: Concept[], lang:'fr' | 'en' ) => {
-  const concept = concepts.find((c)=> c.display === testName)
-  return findLocalDesignationIfExists(concept, lang) || DEFAULT_VALUE
-}
 
 const Prescriptions = ({ clinicalImpressions, prescriptions }: Props): React.ReactElement => {
   const patientState = useSelector((state: State) => state.patient);

--- a/client/src/components/screens/PatientSubmission/components/ClinicalInformation/index.jsx
+++ b/client/src/components/screens/PatientSubmission/components/ClinicalInformation/index.jsx
@@ -23,6 +23,7 @@ import {
 } from 'helpers/fhir/fhir';
 import { getObservationValue } from 'helpers/fhir/fhir';
 import { PrescriptionStatus } from 'helpers/fhir/types';
+import { findLocalDesignationIfExists } from 'helpers/ServiceRequestCode';
 import findIndex from 'lodash/findIndex';
 import get from 'lodash/get';
 import map from 'lodash/map';
@@ -64,11 +65,6 @@ const HpoHiddenFields = ({
 
 export const hpoDisplayName = (key, name) => `${name} (${key})`;
 
-
-const buildAnalysisCheckBoxName = (concept, lang) =>{
-  const designation = concept.designation.find(d => d.language === lang);
-  return designation ? designation.value : concept.display;
-}
 
 class ClinicalInformation extends React.Component {
   constructor(props) {
@@ -415,7 +411,7 @@ class ClinicalInformation extends React.Component {
                     <Checkbox
                       key={concept.code}
                       value={concept.code}
-                    >{ buildAnalysisCheckBoxName(concept, this.props.lang) }
+                    >{ findLocalDesignationIfExists(concept, this.props.lang) || concept.display}
                     </Checkbox>
                   )) 
                 }
@@ -445,7 +441,7 @@ class ClinicalInformation extends React.Component {
                     <Checkbox
                       key={concept.code}
                       value={concept.code}
-                    >{ buildAnalysisCheckBoxName(concept, this.props.lang) }
+                    >{ findLocalDesignationIfExists(concept, this.props.lang) || concept.display }
                     </Checkbox>
                   )) 
                 }

--- a/client/src/helpers/ServiceRequestCode.ts
+++ b/client/src/helpers/ServiceRequestCode.ts
@@ -1,3 +1,8 @@
 import { Concept } from "store/ServiceRequestCodeTypes";
 
-export const findLocalDesignationIfExists = (concept: Concept | undefined, lang: 'fr' | 'en'): string | undefined =>concept?.designation.find(d => d.language === lang)?.value || undefined
+export const findLocalDesignationIfExists = (concept: Concept | undefined, lang: 'fr' | 'en'): string | null =>concept?.designation?.find(d => d.language === lang)?.value || null
+
+export const translateAnalysis = (testName: string, concepts: Concept[], lang:'fr' | 'en' ): string => {
+  const concept = concepts.find((c)=> c.display === testName)
+  return findLocalDesignationIfExists(concept, lang) || '--'
+}

--- a/client/src/helpers/ServiceRequestCode.ts
+++ b/client/src/helpers/ServiceRequestCode.ts
@@ -1,0 +1,3 @@
+import { Concept } from "store/ServiceRequestCodeTypes";
+
+export const findLocalDesignationIfExists = (concept: Concept | undefined, lang: 'fr' | 'en'): string | undefined =>concept?.designation.find(d => d.language === lang)?.value || undefined


### PR DESCRIPTION
# [BUG] Afficher analyse dans page patient

closes #Clin-540

## Description

Le nom de l'analyse dans l'onglet prescription de la page patient ne s'affichait plus
