### PR TITLE
fix: clin-554 dehardcode port number in npm start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "web-vitals": "^0.2.4"
   },
   "scripts": {
-    "start": "PORT=2000 node client/scripts/start.js",
+    "start": "node client/scripts/start.js",
     "build": "node client/scripts/build.js",
     "serve-build": "npx serve -p 2000 -s client/build",
     "test": "node client/scripts/test.js",


### PR DESCRIPTION
# [Build] [avoid harcoding port number in npm script]

closes #[554]