### PR TITLE
fix: CLIN-572 fix organisation id in add parent modal

### DIFF
--- a/client/src/components/screens/Patient/components/FamilyTab/components/AddParentModal.tsx
+++ b/client/src/components/screens/Patient/components/FamilyTab/components/AddParentModal.tsx
@@ -180,7 +180,7 @@ const AddParentModal = ({ onClose, parentType }: Props): React.ReactElement => {
                   <>
                     <dt>{intl.get('screen.patient.details.family.modal.file')}</dt>
                     <dd>{`${selectedPatient.mrn[0]} | ${
-                      selectedPatient.organization?.cid?.split('/')?.[1]
+                      selectedPatient.organization?.cid
                     }`}</dd>
                   </>
                 )}


### PR DESCRIPTION
# [BUG] [fix organization in add parent modal]

closes #[572]

after
![image](https://user-images.githubusercontent.com/54366437/145701208-e19ad0f5-1993-4606-9128-948f95a8d674.png)
