### PR TITLE
clin-499: Changer icon hpo observé

### DIFF
--- a/client/src/components/Utils/getObservedIcon.tsx
+++ b/client/src/components/Utils/getObservedIcon.tsx
@@ -2,8 +2,13 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import { CheckOutlined, CloseOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 
+enum ObservedType {
+  POS = 'POS',
+  NEG = 'NEG',
+}
+
 export const getObservedIcon = (status: string): React.ReactElement => {
-  if (status === 'POS') {
+  if (status === ObservedType.POS) {
     return (
       <CheckOutlined
         aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.observed')}
@@ -11,7 +16,7 @@ export const getObservedIcon = (status: string): React.ReactElement => {
       />
     );
   }
-  if (status === 'NEG') {
+  if (status === ObservedType.NEG) {
     return (
       <CloseOutlined
         aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.negative')}

--- a/client/src/components/Utils/getObservedIcon.tsx
+++ b/client/src/components/Utils/getObservedIcon.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import intl from 'react-intl-universal';
 import { CheckOutlined, CloseOutlined, QuestionCircleOutlined } from '@ant-design/icons';
 
-enum ObservedType {
+enum ObservedStatus {
   POS = 'POS',
   NEG = 'NEG',
 }
 
 export const getObservedIcon = (status: string): React.ReactElement => {
-  if (status === ObservedType.POS) {
+  if (status === ObservedStatus.POS) {
     return (
       <CheckOutlined
         aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.observed')}
@@ -16,7 +16,7 @@ export const getObservedIcon = (status: string): React.ReactElement => {
       />
     );
   }
-  if (status === ObservedType.NEG) {
+  if (status === ObservedStatus.NEG) {
     return (
       <CloseOutlined
         aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.negative')}

--- a/client/src/components/Utils/getObservedIcon.tsx
+++ b/client/src/components/Utils/getObservedIcon.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import intl from 'react-intl-universal';
+import { CheckOutlined, CloseOutlined, QuestionCircleOutlined } from '@ant-design/icons';
+
+export const getObservedIcon = (status: string): React.ReactElement => {
+  if (status === 'POS') {
+    return (
+      <CheckOutlined
+        aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.observed')}
+        className={`observedIcon--positive`}
+      />
+    );
+  }
+  if (status === 'NEG') {
+    return (
+      <CloseOutlined
+        aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.negative')}
+        className={`observedIcon--negative`}
+      />
+    );
+  }
+  
+  return (
+    <QuestionCircleOutlined
+      aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.unknown')}
+    />
+  );
+};

--- a/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescription/ClinicalSigns.tsx
+++ b/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescription/ClinicalSigns.tsx
@@ -23,7 +23,7 @@ const ClinicalSigns: React.FC<Props> = ({ clinicalImpression, hpos }) => {
     category: obs.category,
     key: index,
     notes: obs.note || '--',
-    observed: (<div className='prescriptions-tab__prescriptions-section__clinical-sign__observed'>{getObservedIcon(obs.observed)}</div>),
+    observed: obs.observed,
     term: obs.term,
   }));
 
@@ -38,6 +38,11 @@ const ClinicalSigns: React.FC<Props> = ({ clinicalImpression, hpos }) => {
           {
             dataIndex: 'observed',
             key: 'observed',
+            render: (observed) => (
+              <div className='prescriptions-tab__prescriptions-section__clinical-sign__observed'>
+                {getObservedIcon(observed)}
+              </div>
+            ),
             title: intl.get('screen.patient.details.prescriptions.clinicalSign.observed'),
             width: 80,
           },

--- a/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescription/ClinicalSigns.tsx
+++ b/client/src/components/screens/Patient/components/PrescriptionsTab/components/Prescription/ClinicalSigns.tsx
@@ -1,38 +1,12 @@
 import React from 'react';
-import { Card, Table } from 'antd';
 import intl from 'react-intl-universal';
-import get from 'lodash/get';
-import { EyeFilled, EyeInvisibleFilled, QuestionCircleFilled } from '@ant-design/icons';
+import { Card, Table } from 'antd';
 import { ClinicalImpression, Reference } from 'helpers/fhir/types';
-import { ClinicalObservation } from '../../../../../../../helpers/providers/types';
+import { ClinicalObservation } from 'helpers/providers/types';
+import get from 'lodash/get';
 
-const getObservedIcon = (status: string) => {
-  const prescriptionTabCN = 'prescriptions-tab__prescriptions-section__clinical-sign__observed ';
+import { getObservedIcon } from 'components/Utils/getObservedIcon';
 
-  if (status === 'POS') {
-    return (
-      <EyeFilled
-        className={`${prescriptionTabCN} ${prescriptionTabCN}--positive`}
-        aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.observed')}
-      />
-    );
-  }
-  if (status === 'NEG') {
-    return (
-      <EyeInvisibleFilled
-        className={`${prescriptionTabCN} ${prescriptionTabCN}--negative`}
-        aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.negative')}
-      />
-    );
-  }
-
-  return (
-    <QuestionCircleFilled
-      className={`${prescriptionTabCN} ${prescriptionTabCN}--unknown`}
-      aria-label={intl.get('screen.patient.details.prescriptions.clinicalSign.unknown')}
-    />
-  );
-};
 
 interface Props {
   clinicalImpression: ClinicalImpression
@@ -45,46 +19,46 @@ const ClinicalSigns: React.FC<Props> = ({ clinicalImpression, hpos }) => {
       (item: Reference) => item.reference.indexOf(hpo.id) !== -1,
     ) != null,
   ).map((obs, index) => ({
-    key: index,
-    observed: getObservedIcon(obs.observed),
-    category: obs.category,
-    term: obs.term,
     apparition: obs.ageAtOnset,
+    category: obs.category,
+    key: index,
     notes: obs.note || '--',
+    observed: (<div className='prescriptions-tab__prescriptions-section__clinical-sign__observed'>{getObservedIcon(obs.observed)}</div>),
+    term: obs.term,
   }));
 
   return (
     <Card
-      title={intl.get('screen.patient.details.prescriptions.clinicalSign.title')}
       bordered={false}
       className="prescriptions-tab__prescriptions-section__clinical-sign"
+      title={intl.get('screen.patient.details.prescriptions.clinicalSign.title')}
     >
       <Table
-        pagination={false}
         columns={[
           {
-            key: 'observed',
             dataIndex: 'observed',
+            key: 'observed',
             title: intl.get('screen.patient.details.prescriptions.clinicalSign.observed'),
             width: 80,
           },
           {
-            key: 'term',
             dataIndex: 'term',
+            key: 'term',
             title: intl.get('screen.patient.details.prescriptions.clinicalSign.term'),
           },
           {
-            key: 'apparition',
             dataIndex: 'apparition',
+            key: 'apparition',
             title: intl.get('screen.patient.details.prescriptions.clinicalSign.apparition'),
           },
           {
-            key: 'notes',
             dataIndex: 'notes',
+            key: 'notes',
             title: intl.get('screen.patient.details.prescriptions.clinicalSign.notes'),
           },
         ]}
         dataSource={dataSource}
+        pagination={false}
         size="small"
       />
     </Card>

--- a/client/src/components/screens/Patient/components/PrescriptionsTab/styles.scss
+++ b/client/src/components/screens/Patient/components/PrescriptionsTab/styles.scss
@@ -334,19 +334,8 @@
 
     &__clinical-sign {
       &__observed {
-        display: block;
-        margin:auto;
-        &--positive {
-          color: $green-6;
-        }
-
-        &--negative {
-          color: $red-5;
-        }
-
-        &--unknown {
-          color: $gray-8;
-        }
+        display: flex;
+        justify-content: center;
       }
     }
 

--- a/client/src/components/screens/PatientSubmission/components/ClinicalInformation/index.jsx
+++ b/client/src/components/screens/PatientSubmission/components/ClinicalInformation/index.jsx
@@ -1,8 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 /* eslint-disable react/prop-types */
 import React from 'react';
-import IconKit from 'react-icons-kit';
-import { ic_help, ic_visibility, ic_visibility_off } from 'react-icons-kit/md';
 import intl from 'react-intl-universal';
 import { connect } from 'react-redux';
 import {
@@ -30,17 +28,13 @@ import map from 'lodash/map';
 import toArray from 'lodash/values';
 import { bindActionCreators } from 'redux';
 
+import { getObservedIcon } from 'components/Utils/getObservedIcon';
+
 import ErrorText from './components/ErrorText';
 import FamilyStorySection from './components/FamilyStorySection';
 import InvestigationSection from './components/InvestigationSection';
 import MrnItem from './components/MrnItem';
 import OntologyTree from './components/OntologyTree';
-
-const interpretationIcon = {
-  IND: ic_help,
-  NEG: ic_visibility_off,
-  POS: ic_visibility,
-};
 
 const ROOT_PHENOTYPE = 'Phenotypic abnormality (HP:0000118)';
 
@@ -185,11 +179,7 @@ class ClinicalInformation extends React.Component {
                     key={`hpoInterpretation_${index}`}
                     value={interpretation.value}
                   >
-                    <IconKit
-                      className={`${interpretation.iconClass} icon`}
-                      icon={interpretationIcon[interpretation.value]}
-                      size={14}
-                    />
+                    <div className='icon'>{ getObservedIcon(interpretation.value) }</div>
                     { interpretation.display }
                   </Select.Option>
                 )) }

--- a/client/src/components/screens/PatientSubmission/style.scss
+++ b/client/src/components/screens/PatientSubmission/style.scss
@@ -298,18 +298,6 @@
         &:first-child{
           margin-right: 8px;
         }
-        .icon{
-          margin-right: 4px;
-        }
-        .observedIcon{
-          color: #52C41A;;
-        }
-        .notObservedIcon{
-          color: #FF4D4F;;
-        }
-        .unknownIcon{
-          color:#536377;
-        }
       }
     }
 
@@ -397,16 +385,8 @@
 .selectDropdown{
   .icon{
     margin-right: 4px;
+    display: inline;
   }
-    .observedIcon{
-      color: #52C41A;;
-    }
-    .notObservedIcon{
-      color: #FF4D4F;;
-    }
-    .unknownIcon{
-      color:#536377;
-    }
 }
 
 .submission-form-actions{

--- a/client/src/style/themes/clin/main.scss
+++ b/client/src/style/themes/clin/main.scss
@@ -4,3 +4,12 @@
 html {
   font-size: 12px;
 }
+
+.observedIcon{
+  &--positive{
+    color:$green-7;
+  }
+  &--negative{
+    color:$red-8;
+  }
+}


### PR DESCRIPTION
# [FEATUER] [Changer icones hpo observé]

closes clin-499

## Description

Nouvelle icônes pour les signe clinique observé / non observé, dans la page patient/prescription et dans le formulaire de prescription
