### PR TITLE
fix: CLIN-287 Masquer les erreur et warnings dans la console

### DIFF
--- a/client/src/AppTest.tsx
+++ b/client/src/AppTest.tsx
@@ -209,12 +209,12 @@ const AppTest: React.FC<Props> = ({ children, additionalStateInfo = {} }) => {
   });
   window.CLIN = {
     namespace: 'dev',
-    patientServiceApiUrl: 'https://patient.qa.clin.ferlab.bio/patient',
-    variantServiceApiUrl: 'https://variant.qa.clin.ferlab.bio/variant',
-    geneServiceApiUrl: 'https://gene.qa.clin.ferlab.bio/gene',
-    metaServiceApiUrl: 'https://meta.qa.clin.ferlab.bio/meta',
-    fhirBaseUrl: 'https://fhir.qa.clin.ferlab.bio/fhir',
-    hpoBaseUrl: 'https://hpo.qa.clin.ferlab.bio/hpo',
+    patientServiceApiUrl: 'https://patient.qa.cqgc.hsj.rtss.qc.ca/patient',
+    variantServiceApiUrl: 'https://variant.qa.cqgc.hsj.rtss.qc.ca/variant',
+    geneServiceApiUrl: 'https://gene.qa.cqgc.hsj.rtss.qc.ca/gene',
+    metaServiceApiUrl: 'https://meta.qa.cqgc.hsj.rtss.qc.ca/meta',
+    fhirBaseUrl: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir',
+    hpoBaseUrl: 'https://hpo.qa.cqgc.hsj.rtss.qc.ca/hpo',
     // @ts-ignore
     translate: null,
     defaultUsername: '',

--- a/client/src/__tests__/utils/Utils.ts
+++ b/client/src/__tests__/utils/Utils.ts
@@ -67,7 +67,7 @@ export class ResourceBuilder {
         type: 'transaction-response',
         link: [{
           relation: 'self',
-          url: 'https://fhir.qa.clin.ferlab.bio/fhir',
+          url: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir',
         }],
         entry: [],
       };
@@ -106,7 +106,7 @@ export class ResourceBuilder {
 
       this.practitioners.forEach((practitioner, index) => {
         entries.push({
-          fullUrl: `https://fhir.qa.clin.ferlab.bio/fhir/Practitioner/${practitioner.id || index.toString()}`,
+          fullUrl: `https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Practitioner/${practitioner.id || index.toString()}`,
           resource: {
             resourceType: 'Practitioner',
             id: `${practitioner.id || index.toString()}`,

--- a/client/src/components/screens/Patient/components/FamilyTab/tests/family.spec.tsx
+++ b/client/src/components/screens/Patient/components/FamilyTab/tests/family.spec.tsx
@@ -7,6 +7,15 @@ import FamilyTab from '../index';
 import { patientNotProbandSubState, patientProbandSubState } from './mockData';
 
 describe('Family', () => {
+
+  beforeEach(() => {
+    console.error = jest.fn(); //Pour masquer les "console.error"
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   const renderComponent = (subState: Record<string, unknown>) =>
     render(
       <AppTest additionalStateInfo={{ ...subState }}>

--- a/client/src/components/screens/Patient/components/FilesTab/tests/files.spec.tsx
+++ b/client/src/components/screens/Patient/components/FilesTab/tests/files.spec.tsx
@@ -21,12 +21,12 @@ const renderComponents = (
 describe('PatientFiles', () => {
 
   beforeEach(() => {
-    console.error = jest.fn();
     (useFilesData as jest.Mock).mockReset();
+    console.error = jest.fn(); //Pour masquer les "console.error"
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.clearAllMocks(); //Pour masquer les "console.error"
   });
 
   test('shoud show empty page when no file', async () => {

--- a/client/src/components/screens/Patient/components/FilesTab/tests/mockData.tsx
+++ b/client/src/components/screens/Patient/components/FilesTab/tests/mockData.tsx
@@ -38,14 +38,14 @@ export const manyFilesData = {
                 "attachment": {
                     "hash": "ZmU0Mzg5NWMyNDY2ZTNiY2QyYmU3OGMyMmNhY2YzYjA=",
                     "title": "16775.hard-filtered.gvcf.gz",
-                    "url": "https://ferload.qa.clin.ferlab.bio/8ce34a42-9ec8-4a19-953b-1e1e25345cf2"
+                    "url": "https://ferload.qa.cqgc.hsj.rtss.qc.ca/8ce34a42-9ec8-4a19-953b-1e1e25345cf2"
                 },
                 "format": "VCF"
                 },
                 {
                 "attachment": {
                     "title": "16775.hard-filtered.gvcf.gz.tbi",
-                    "url": "https://ferload.qa.clin.ferlab.bio/8ce34a42-9ec8-4a19-953b-1e1e25345cf2.tbi"
+                    "url": "https://ferload.qa.cqgc.hsj.rtss.qc.ca/8ce34a42-9ec8-4a19-953b-1e1e25345cf2.tbi"
                 },
                 "format": "TBI"
                 }
@@ -101,7 +101,7 @@ export const manyFilesData = {
                 {
                 "attachment": {
                     "title": "16775.QC.tgz",
-                    "url": "https://ferload.qa.clin.ferlab.bio/48700352-aeec-4569-a053-f6fdc0baee08"
+                    "url": "https://ferload.qa.cqgc.hsj.rtss.qc.ca/48700352-aeec-4569-a053-f6fdc0baee08"
                 },
                 "format": "TGZ"
                 }
@@ -158,14 +158,14 @@ export const manyFilesData = {
                 "attachment": {
                     "hash": "MzQ5NDc5OGViM2RmMDY4MWRiMmY2YzI0ZTJiMzdiYzY=",
                     "title": "16775.cram",
-                    "url": "https://ferload.qa.clin.ferlab.bio/ad6cb890-991e-4cfe-85c8-12fb33db44ad"
+                    "url": "https://ferload.qa.cqgc.hsj.rtss.qc.ca/ad6cb890-991e-4cfe-85c8-12fb33db44ad"
                 },
                 "format": "CRAM"
                 },
                 {
                 "attachment": {
                     "title": "16775.cram.crai",
-                    "url": "https://ferload.qa.clin.ferlab.bio/ad6cb890-991e-4cfe-85c8-12fb33db44ad.crai"
+                    "url": "https://ferload.qa.cqgc.hsj.rtss.qc.ca/ad6cb890-991e-4cfe-85c8-12fb33db44ad.crai"
                 },
                 "format": "CRAI"
                 }

--- a/client/src/components/screens/PatientCreation/tests/files.spec.tsx
+++ b/client/src/components/screens/PatientCreation/tests/files.spec.tsx
@@ -8,7 +8,6 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 
 import AppTest from 'AppTest';
-//import PatientSearchScreen from 'components/screens/PatientSearch';
 import PatientCreation from '../../PatientCreation';
 import { mockRptToken } from '__tests__/mocks';
 
@@ -44,14 +43,14 @@ describe('PatientCreation', () => {
     }
 
     server.use(
-      rest.post('https://fhir.qa.clin.ferlab.bio/fhir/', (req, res, ctx) => res(
+      rest.post('https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/', (req, res, ctx) => res(
         ctx.status(200),
         ctx.json({
           entry: responseEntries,
           id: 'f3d8da0f-da55-44fd-942a-6760543cec4b',
           link: [{
             relation: 'self',
-            url: 'https://fhir.qa.clin.ferlab.bio/fhir',
+            url: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir',
           }],
           resourceType: 'Bundle',
           type: 'transaction-response',
@@ -60,8 +59,15 @@ describe('PatientCreation', () => {
     );
   }
 
+  beforeEach(() => {
+    console.error = jest.fn(); //Pour masquer les "console.error"
+    console.warn = jest.fn(); //Pour masquer les "console.warning"
+    console.log = jest.fn(); //Pour masquer les "console.log"
+  });
+
   afterEach(() => {
     server.resetHandlers();
+    jest.clearAllMocks();
   });
 
   afterAll(() => {
@@ -72,13 +78,13 @@ describe('PatientCreation', () => {
     test('with a new RAMQ', async () => {
       mockRptToken();
       server.use(
-        rest.get('https://fhir.qa.clin.ferlab.bio/fhir/Patient', (req, res, ctx) => res(
+        rest.get('https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient', (req, res, ctx) => res(
           ctx.status(200),
           ctx.json({
             id: '2acbea67-8d49-477b-bbae-7acb18430780',
             link: [{
               relation: 'self',
-              url: 'https://fhir.qa.clin.ferlab.bio/fhir/Patient?identifier=DABC01010101',
+              url: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient?identifier=DABC01010101',
             }],
             meta: {
               lastUpdated: '2021-03-19T18:49:41.787+00:00',
@@ -129,7 +135,7 @@ describe('PatientCreation', () => {
     test("with a new mother's RAMQ", async () => {
       mockRptToken();
       server.use(
-        rest.get('https://fhir.qa.clin.ferlab.bio/fhir/Patient', (req, res, ctx) => res(
+        rest.get('https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient', (req, res, ctx) => res(
           ctx.status(200),
           ctx.json({
             id: '2acbea67-8d49-477b-bbae-7acb18430780',
@@ -185,12 +191,12 @@ describe('PatientCreation', () => {
       const ramq = 'BETS00000001';
 
       server.use(
-        rest.get('https://fhir.qa.clin.ferlab.bio/fhir/Patient', (req, res, ctx) => {
+        rest.get('https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient', (req, res, ctx) => {
           let entry;
 
           if (req.url.href.includes(ramq)) {
             entry = [{
-              fullUrl: 'https://fhir.qa.clin.ferlab.bio/fhir/Patient/54382',
+              fullUrl: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient/54382',
               resource: {
                 active: true,
                 birthDate: '2021-03-30',
@@ -316,11 +322,11 @@ describe('PatientCreation', () => {
     test('with an existing RAMQ', async () => {
       mockRptToken();
       server.use(
-        rest.get('https://fhir.qa.clin.ferlab.bio/fhir/Patient', (req, res, ctx) => res(
+        rest.get('https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient', (req, res, ctx) => res(
           ctx.status(200),
           ctx.json({
             entry: [{
-              fullUrl: 'https://fhir.qa.clin.ferlab.bio/fhir/Patient/54382',
+              fullUrl: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient/54382',
               resource: {
                 id: '54382',
                 extension: [{
@@ -393,7 +399,7 @@ describe('PatientCreation', () => {
             id: '2acbea67-8d49-477b-bbae-7acb18430780',
             link: [{
               relation: 'self',
-              url: 'https://fhir.qa.clin.ferlab.bio/fhir/Patient?identifier=BETS00000001',
+              url: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient?identifier=BETS00000001',
             }],
             meta: {
               lastUpdated: '2021-03-19T18:49:41.787+00:00',
@@ -423,11 +429,11 @@ describe('PatientCreation', () => {
     test('with an existing MRN', async () => {
       mockRptToken();
       server.use(
-        rest.get('https://fhir.qa.clin.ferlab.bio/fhir/Patient', (req, res, ctx) => {
+        rest.get('https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient', (req, res, ctx) => {
           let entry;
           if (req.url.href.includes('CUSM') && req.url.href.includes('010000')) {
             entry = [{
-              fullUrl: 'https://fhir.qa.clin.ferlab.bio/fhir/Patient/54382',
+              fullUrl: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient/54382',
               resource: {
                 active: true,
                 birthDate: '2021-03-30',
@@ -548,11 +554,11 @@ describe('PatientCreation', () => {
     test('when finding a patient with their RAMQ', async () => {
       mockRptToken();
       server.use(
-        rest.get('https://fhir.qa.clin.ferlab.bio/fhir/Patient', (req, res, ctx) => res(
+        rest.get('https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient', (req, res, ctx) => res(
           ctx.status(200),
           ctx.json({
             entry: [{
-              fullUrl: 'https://fhir.qa.clin.ferlab.bio/fhir/Patient/54382',
+              fullUrl: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient/54382',
               resource: {
                 id: '54382',
                 extension: [{
@@ -625,7 +631,7 @@ describe('PatientCreation', () => {
             id: '2acbea67-8d49-477b-bbae-7acb18430780',
             link: [{
               relation: 'self',
-              url: 'https://fhir.qa.clin.ferlab.bio/fhir/Patient?identifier=BETS00000001',
+              url: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient?identifier=BETS00000001',
             }],
             meta: {
               lastUpdated: '2021-03-19T18:49:41.787+00:00',
@@ -662,13 +668,13 @@ describe('PatientCreation', () => {
     test('when changing the patient type', async () => {
       mockRptToken();
       server.use(
-        rest.get('https://fhir.qa.clin.ferlab.bio/fhir/Patient', (req, res, ctx) => res(
+        rest.get('https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient', (req, res, ctx) => res(
           ctx.status(200),
           ctx.json({
             id: '2acbea67-8d49-477b-bbae-7acb18430780',
             link: [{
               relation: 'self',
-              url: 'https://fhir.qa.clin.ferlab.bio/fhir/Patient?identifier=BETS00000001',
+              url: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient?identifier=BETS00000001',
             }],
             meta: {
               lastUpdated: '2021-03-19T18:49:41.787+00:00',
@@ -715,13 +721,13 @@ describe('PatientCreation', () => {
     test('MRN should only accept alpha numerical charactar', async () => {
       mockRptToken();
       server.use(
-      rest.get('https://fhir.qa.clin.ferlab.bio/fhir/Patient', (req, res, ctx) => res(
+      rest.get('https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient', (req, res, ctx) => res(
         ctx.status(200),
         ctx.json({
         id: '2acbea67-8d49-477b-bbae-7acb18430780',
         link: [{
             relation: 'self',
-            url: 'https://fhir.qa.clin.ferlab.bio/fhir/Patient?identifier=DABC01010101',
+            url: 'https://fhir.qa.cqgc.hsj.rtss.qc.ca/fhir/Patient?identifier=DABC01010101',
         }],
         meta: {
             lastUpdated: '2021-03-19T18:49:41.787+00:00',

--- a/client/src/helpers/fhir/__tests/PractitionerRoleHelper.spec.ts
+++ b/client/src/helpers/fhir/__tests/PractitionerRoleHelper.spec.ts
@@ -1,6 +1,6 @@
 import { findPractitionerRoleByOrganizationRef, isPractitionerResident } from '../PractitionerRoleHelper'
 import * as mocks from './PractitionerRoleHelper.mocks'
-import { PractitionerRole } from "./types"
+import { PractitionerRole } from "../types"
 
 describe('PractitionerRoleHelper', () => {
 

--- a/client/src/helpers/fhir/__tests/ServiceRequestNotesHelper.spec.ts
+++ b/client/src/helpers/fhir/__tests/ServiceRequestNotesHelper.spec.ts
@@ -1,19 +1,20 @@
 import { getNoteComment, getNoteStatus, updateNoteComment, updateNoteStatus } from '../ServiceRequestNotesHelper'
+import { Note, ServiceRequest } from '../types';
 import * as mocks from './ServiceRequestNotesHelper.mocks'
 
 describe('ServiceRequest GET Note Comment', () => {
 
   test('getNoteComment - should return note comment', () => {
-    expect(getNoteComment(mocks.serviceRequestCommentOnly)).toEqual('foo')
+    expect(getNoteComment(mocks.serviceRequestCommentOnly as ServiceRequest)).toEqual('foo')
   })
 
   test('getNoteComment - should ignore -- string', () => {
-    expect(getNoteComment(mocks.serviceRequestEmptyComment)).toBeUndefined
+    expect(getNoteComment(mocks.serviceRequestEmptyComment as ServiceRequest)).toBeUndefined
   })
 
   test('getNoteComment - should be robust to missing data', () => {
     expect(getNoteComment(null)).toBeUndefined
-    expect(getNoteComment({})).toBeUndefined
+    expect(getNoteComment({} as ServiceRequest)).toBeUndefined
   })
 
 })
@@ -21,17 +22,17 @@ describe('ServiceRequest GET Note Comment', () => {
 describe('ServiceRequest GET Note Status', () => {
 
   test('getNoteStatus - should return note status', () => {
-    expect(getNoteStatus(mocks.serviceRequestCommentAndStatus)).toEqual('bar')
+    expect(getNoteStatus(mocks.serviceRequestCommentAndStatus as ServiceRequest)).toEqual('bar')
   })
 
   test('getNoteStatus - should ignore -- string', () => {
-    expect(getNoteComment(mocks.serviceRequestEmptyCommentAndStatus)).toBeUndefined
+    expect(getNoteComment(mocks.serviceRequestEmptyCommentAndStatus as ServiceRequest)).toBeUndefined
   })
 
   test('getNoteStatus - should be robust to missing data', () => {
-    expect(getNoteStatus(mocks.serviceRequestCommentOnly)).toBeUndefined
+    expect(getNoteStatus(mocks.serviceRequestCommentOnly as ServiceRequest)).toBeUndefined
     expect(getNoteStatus(null)).toBeUndefined
-    expect(getNoteStatus({})).toBeUndefined
+    expect(getNoteStatus({} as ServiceRequest)).toBeUndefined
   })
 
 })
@@ -39,7 +40,7 @@ describe('ServiceRequest GET Note Status', () => {
 describe('ServiceRequest UPDATE Note Comment', () => {
 
   test('updateNoteComment - should add note comment', () => {
-    const notes = []
+    const notes: Note[] | undefined = []
     const updated = updateNoteComment({ text: 'new comment' }, notes)
     expect(updated[0].text).toEqual('new comment')
   })


### PR DESCRIPTION
# [CLIN-287] Fixer le probleme de 'async=validator' dans les tests

closes #CLIN-287

## Description

Masquer les erreur, warning et log dans la console lors de l'exécution des tests automatisés.
Corriger au passage certaines erreurs dans les fichiers de tests.

## Validation

- [X] Test Coverage
- [X] QA Done
- [X] Design/UI Approved from design