### PR TITLE
feat: CLIN-868 Ajout du test unitaire pour ce bug

### DIFF
--- a/client/src/helpers/fhir/patientHelper.spec.ts
+++ b/client/src/helpers/fhir/patientHelper.spec.ts
@@ -16,6 +16,11 @@ describe('Helper: PatientHelper', () => {
       expect(getDetailsFromRamq('20200101SMIM')).toBeNull();
       expect(getDetailsFromRamq('SMIM20200101')).toBeNull();
       expect(getDetailsFromRamq('SMIM20990101')).toBeNull();
+//CLIN-868 expect(getDetailsFromRamq('SMIM205901010')).toBeNull();
+      expect(getDetailsFromRamq('SMIM2059010101')).toBeNull();
+      expect(getDetailsFromRamq('SMIMM2059010')).toBeNull();
+      expect(getDetailsFromRamq('SMIMM20590101')).toBeNull();
+      expect(getDetailsFromRamq('SMI320590101')).toBeNull();
     });
 
     test('should return valid RamqDetails from valid ramq', () => {
@@ -49,7 +54,7 @@ describe('Helper: PatientHelper', () => {
       } as RamqDetails);
     });
 
-    test('should should handle 99 years old', () => {
+    test('should handle 99 years old', () => {
       const nextYear = moment().add(1, 'year');
       const expectedYear = nextYear.subtract(100, 'years');
       expect(getDetailsFromRamq(`SMIS${nextYear.format('YY')}512301`)).toEqual({


### PR DESCRIPTION
# [QA] Test unitaire pour CLIN-868

open #CLIN-868

## Description

Ajout de tests unitaires pour la validation de la RAMQ

- Ajout d'un test unitaire à faire fonctionner pour corriger le bug CLIN-868
    - Un numéro composé de 4 lettres et 9 chiffres devrait être invalide
- Ajout d'autres tests unitaires pour la RAMQ

## Validation

- [X] Test Coverage
- [X] QA Done
- [X] Design/UI Approved from design