### PR TITLE
feat: CLIN-795 Activation du test skippé

### DIFF
--- a/client/src/helpers/fhir/__tests/PatientBuilder.spec.ts
+++ b/client/src/helpers/fhir/__tests/PatientBuilder.spec.ts
@@ -224,8 +224,7 @@ describe('PatientBuilder', () => {
     })
   })
 
-  //En attente de la correction de CLIN-795
-  describe.skip('withPatient', () => {
+  describe('withPatient', () => {
     test('should build partial patient', () => {
         const builder = new PatientBuilder()
         const patient = mocks.PartialPatientMock as Partial<Patient>;


### PR DESCRIPTION
# [QA] Activation d'un test skippé bloqué par CLIN-795

closes #CLIN-795

## Description

Le test skippé était en attente de la correction de CLIN-795

## Validation

- [X] Test Coverage
- [X] QA Done
- [X] Design/UI Approved from design
